### PR TITLE
Fix domain references to baddbeats.nl

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,5 +6,5 @@ main = "workers-site/index.js"
 [site]
 bucket = "./"
 routes = [
-  { pattern = "www.baddbeatz.nl", custom_domain = true }
+  { pattern = "www.baddbeats.nl", custom_domain = true }
 ]


### PR DESCRIPTION
## Summary
- update domain in wrangler.toml

## Testing
- `npm test` *(fails: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684177052fdc832889c4746edc360ca7