### PR TITLE
Fix domain references to baddbeatz.nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the static portfolio website for **TheBadGuy (TBG)** – a high-energy u
 ## 🚀 Project Structure
 
 ```
-baddbeats/
+baddbeatz/
 ├── index.html
 ├── about.html
 ├── music.html
@@ -31,11 +31,11 @@ baddbeats/
 ### 1. Login to [Cloudflare Pages](https://pages.cloudflare.com/)
 ### 2. Create a new project:
 - Choose **"Direct Upload"**
-- Upload the entire contents of the `baddbeats/` folder
+- Upload the entire contents of the `baddbeatz/` folder
 
 ### 3. Set your custom domain:
 - In your Cloudflare dashboard, go to **Pages > Settings > Custom Domains**
-- Add: `baddbeats.nl`
+- Add: `baddbeatz.nl`
 
 ---
 

--- a/bookings.html
+++ b/bookings.html
@@ -45,7 +45,7 @@
       <button type="submit">Send Booking Request</button>
     </form>
 
-    <p class="alt-contact">Prefer direct contact? Email: <a href="mailto:bookings@baddbeats.nl">bookings@baddbeats.nl</a></p>
+    <p class="alt-contact">Prefer direct contact? Email: <a href="mailto:bookings@baddbeatz.nl">bookings@baddbeatz.nl</a></p>
   </main>
 
   <footer>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://baddbeats.nl/sitemap.xml
+Sitemap: https://baddbeatz.nl/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://baddbeats.nl/</loc>
+    <loc>https://baddbeatz.nl/</loc>
   </url>
   <url>
-    <loc>https://baddbeats.nl/about.html</loc>
+    <loc>https://baddbeatz.nl/about.html</loc>
   </url>
   <url>
-    <loc>https://baddbeats.nl/music.html</loc>
+    <loc>https://baddbeatz.nl/music.html</loc>
   </url>
   <url>
-    <loc>https://baddbeats.nl/gallery.html</loc>
+    <loc>https://baddbeatz.nl/gallery.html</loc>
   </url>
   <url>
-    <loc>https://baddbeats.nl/bookings.html</loc>
+    <loc>https://baddbeatz.nl/bookings.html</loc>
   </url>
   <url>
-    <loc>https://baddbeats.nl/contact.html</loc>
+    <loc>https://baddbeatz.nl/contact.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- use baddbeatz.nl in Cloudflare routing
- update robots.txt to baddbeatz.nl
- update sitemap and booking contact link
- refresh README instructions

## Testing
- `npm test` *(fails: no test specified)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684177052fdc832889c4746edc360ca7