### PR TITLE
Integrate Cloudflare Worker and add missing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,17 @@ baddbeats/
 - Add hover effects (glow / pulse)
 - Optimize images with WebP support
 - Social preview meta tags (Open Graph / Twitter Cards)
+
+---
+
+## 🤖 AI Chat Setup
+
+The homepage chat feature sends questions to a Cloudflare Worker endpoint.
+Set your OpenAI API key as a secret so the worker can contact the API:
+
+```bash
+wrangler secret put OPENAI_API_KEY
+```
+
+Or configure the variable in the Cloudflare dashboard. The frontend calls
+`/api/ask` which the worker proxies to OpenAI.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Background and story of TheBadGuyHimself, the driving force behind BaddBeats.">
+  <title>About | TheBadGuy</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <div class="logo">BaddBeats</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="gallery.html">Gallery</a></li>
+        <li><a href="bookings.html">Bookings</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="about-section">
+    <h1>TheBadGuyHimself</h1>
+    <p>Forged in the underground, TBG mixes relentless techno with rawstyle energy. With over four years of experience, he commands crowds with heavy drops and flawless transitions.</p>
+    <p>From intimate clubs to festival stages, TheBadGuy brings a unique vibe that keeps the dancefloor moving all night.</p>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -53,18 +53,13 @@
       responseBox.textContent = 'Thinking...';
 
       try {
-        const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        const res = await fetch("/api/ask", {
           method: "POST",
           headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${window.env.OPENAI_API_KEY}`
+            "Content-Type": "application/json"
           },
           body: JSON.stringify({
-            model: "gpt-3.5-turbo",
-            messages: [
-              { role: "system", content: "You are an AI DJ assistant for TheBadGuyHimself." },
-              { role: "user", content: input }
-            ]
+            question: input
           })
         });
 

--- a/music.html
+++ b/music.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Listen to the latest mixes and releases from TheBadGuyHimself.">
+  <title>Music | TheBadGuy</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <div class="logo">BaddBeats</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="gallery.html">Gallery</a></li>
+        <li><a href="bookings.html">Bookings</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="music-section">
+    <h1>Latest Mix</h1>
+    <audio controls>
+      <source src="assets/audio/mix1.mp3" type="audio/mpeg">
+      Your browser does not support the audio element.
+    </audio>
+    <p class="stream-links">More tracks on <a href="https://on.soundcloud.com/6TGFmDKrTPA1uUHj8" target="_blank">SoundCloud</a>.</p>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,17 +1,41 @@
-import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
+import { getAssetFromKV } from '@cloudflare/kv-asset-handler';
 
-addEventListener('fetch', event => {
-  event.respondWith(handleEvent(event))
-})
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
 
-async function handleEvent(event) {
-  try {
-    return await getAssetFromKV(event)
-  } catch (e) {
-    let pathname = new URL(event.request.url).pathname
-    return new Response(`"${pathname}" not found`, {
-      status: 404,
-      statusText: 'not found'
-    })
+    if (url.pathname === '/api/ask' && request.method === 'POST') {
+      try {
+        const { question } = await request.json();
+        const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${env.OPENAI_API_KEY}`
+          },
+          body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            messages: [
+              { role: 'system', content: 'You are an AI DJ assistant for TheBadGuyHimself.' },
+              { role: 'user', content: question }
+            ]
+          })
+        });
+
+        return new Response(await aiRes.text(), {
+          status: aiRes.status,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      } catch (err) {
+        return new Response('AI request failed', { status: 500 });
+      }
+    }
+
+    try {
+      return await getAssetFromKV({ request, waitUntil: ctx.waitUntil.bind(ctx) });
+    } catch (e) {
+      const pathname = url.pathname;
+      return new Response(`"${pathname}" not found`, { status: 404, statusText: 'not found' });
+    }
   }
-}
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,7 @@ bucket = "./"
 routes = [
   { pattern = "www.baddbeatz.nl", custom_domain = true }
 ]
+
+[vars]
+# Add your OpenAI API key in the Cloudflare dashboard or via `wrangler secret put`.
+OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"


### PR DESCRIPTION
## Summary
- add missing `about.html` and `music.html`
- connect homepage chat to new `/api/ask` endpoint
- implement Cloudflare Worker that forwards `/api/ask` requests to OpenAI
- document worker setup and secrets in README
- configure `OPENAI_API_KEY` variable in `wrangler.toml`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68417a4406588328854381a3dc65c7dd