### PR TITLE
Embed SoundCloud player on music page

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -123,6 +123,10 @@
         grid-template-columns: 1fr;
     }
 
+    .music-grid {
+        grid-template-columns: 1fr;
+    }
+
     /* Contact Form */
     .contact-form {
         width: 100%;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,3 +93,16 @@ body {
   height: auto;
   border-radius: 10px;
 }
+
+/* Music embeds grid */
+.music-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 2rem;
+}
+
+.music-grid iframe {
+  width: 100%;
+  border: none;
+}

--- a/music.html
+++ b/music.html
@@ -24,7 +24,24 @@
   </header>
   <main class="music-section">
     <h1>Latest Mixes</h1>
-    <p>Check back soon for a curated selection of sets and releases.</p>
+    <div class="music-grid">
+      <iframe
+        width="100%"
+        height="300"
+        scrolling="no"
+        frameborder="no"
+        allow="autoplay"
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true">
+      </iframe>
+      <iframe
+        width="100%"
+        height="166"
+        scrolling="no"
+        frameborder="no"
+        allow="autoplay"
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2094603729&color=%23ff5500&auto_play=false&show_user=true">
+      </iframe>
+    </div>
   </main>
   <footer>
     <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>

--- a/music.html
+++ b/music.html
@@ -29,7 +29,7 @@
         width="100%"
         height="300"
         scrolling="no"
-        frameborder="no"
+        
         allow="autoplay"
         src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true">
       </iframe>


### PR DESCRIPTION
## Summary
- embed SoundCloud playlist and track on `music.html`
- arrange embedded iframes using new `.music-grid` styles
- make `.music-grid` responsive with CSS

## Testing
- `npm test --silent`
- `pytest -q` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc5b7b7c832894fcc65780ca4da5