### PR TITLE
Update playlist test

### DIFF
--- a/music.html
+++ b/music.html
@@ -25,6 +25,12 @@
   <main class="music-section">
     <h1>Latest Mixes</h1>
     <p>Check back soon for a curated selection of sets and releases.</p>
+    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+    <div style="font-size: 10px; color: #cccccc; line-break: anywhere; word-break: normal; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif; font-weight: 100;">
+      <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank" style="color: #cccccc; text-decoration: none;">TBGxTheBadGuy</a>
+      ·
+      <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank" style="color: #cccccc; text-decoration: none;">House mixes 2025</a>
+    </div>
   </main>
   <footer>
     <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>

--- a/tests/socialLinks.test.js
+++ b/tests/socialLinks.test.js
@@ -8,7 +8,7 @@ test('contact page has updated social links', () => {
   expect(html).toContain('https://soundcloud.com/thebadguyhimself');
 });
 
-test('index page embeds the SoundCloud playlist', () => {
-  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+test('music page embeds the SoundCloud playlist', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'music.html'), 'utf8');
   expect(html).toContain('https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421');
 });


### PR DESCRIPTION
## Summary
- check for SoundCloud playlist on music page
- embed the playlist widget on the music page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc6e0da8832895899dc9dc695751