### PR TITLE
Embed SoundCloud playlist on music page

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -123,6 +123,10 @@
         grid-template-columns: 1fr;
     }
 
+    .music-grid {
+        grid-template-columns: 1fr;
+    }
+
     /* Contact Form */
     .contact-form {
         width: 100%;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,3 +93,36 @@ body {
   height: auto;
   border-radius: 10px;
 }
+
+/* Music embeds grid */
+.music-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 2rem;
+}
+
+.music-grid iframe {
+  width: 100%;
+  border: none;
+}
+
+/* SoundCloud credit text */
+.sc-credit {
+  font-size: 0.75rem;
+  color: #cccccc;
+  line-break: anywhere;
+  word-break: normal;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: Interstate, Lucida Grande, Lucida Sans Unicode, Lucida Sans,
+    Garuda, Verdana, Tahoma, sans-serif;
+  font-weight: 100;
+  margin-top: 0.5rem;
+}
+
+.sc-credit a {
+  color: #cccccc;
+  text-decoration: none;
+}

--- a/music.html
+++ b/music.html
@@ -24,7 +24,29 @@
   </header>
   <main class="music-section">
     <h1>Latest Mixes</h1>
-    <p>Check back soon for a curated selection of sets and releases.</p>
+    <div class="music-grid">
+      <iframe
+        width="100%"
+        height="300"
+        scrolling="no"
+        frameborder="no"
+        allow="autoplay"
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true">
+      </iframe>
+      <iframe
+        width="100%"
+        height="166"
+        scrolling="no"
+        frameborder="no"
+        allow="autoplay"
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2094603729&color=%23ff5500&auto_play=false&show_user=true">
+      </iframe>
+    </div>
+    <div class="sc-credit">
+      <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+      &middot;
+      <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a>
+    </div>
   </main>
   <footer>
     <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>

--- a/music.html
+++ b/music.html
@@ -42,9 +42,9 @@
       </iframe>
     </div>
     <div class="sc-credit">
-      <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+      <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank" rel="noopener noreferrer">TBGxTheBadGuy</a>
       &middot;
-      <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a>
+      <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank" rel="noopener noreferrer">House mixes 2025</a>
     </div>
   </main>
   <footer>


### PR DESCRIPTION
## Summary
- embed SoundCloud playlist and track on `music.html`
- add credit link under the embedded players
- style credit text with new `.sc-credit` class

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bc5b7b7c832894fcc65780ca4da5