### PR TITLE
Embed SoundCloud playlist with styling cleanup

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -123,6 +123,10 @@
         grid-template-columns: 1fr;
     }
 
+    .music-grid {
+        grid-template-columns: 1fr;
+    }
+
     /* Contact Form */
     .contact-form {
         width: 100%;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,3 +93,41 @@ body {
   height: auto;
   border-radius: 10px;
 }
+
+/* Music embeds grid */
+.music-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 2rem;
+}
+
+.music-grid > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.music-grid iframe {
+  width: 100%;
+  border: none;
+}
+
+/* SoundCloud credit text */
+.sc-credit {
+  font-size: 0.75rem;
+  color: #cccccc;
+  line-break: anywhere;
+  word-break: normal;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: Interstate, Lucida Grande, Lucida Sans Unicode, Lucida Sans,
+    Garuda, Verdana, Tahoma, sans-serif;
+  font-weight: 100;
+  margin-top: 0.5rem;
+}
+
+.sc-credit a {
+  color: #cccccc;
+  text-decoration: none;
+}

--- a/index.html
+++ b/index.html
@@ -29,12 +29,8 @@
     </section>
       <section class="featured-mix">
         <h2>🔥 Featured Mix</h2>
-        <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-        <div style="font-size: 10px; color: #cccccc; line-break: anywhere; word-break: normal; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif; font-weight: 100;">
-          <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank" style="color: #cccccc; text-decoration: none;">TBGxTheBadGuy</a>
-          ·
-          <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank" style="color: #cccccc; text-decoration: none;">House mixes 2025</a>
-        </div>
+        <iframe width="100%" height="300" scrolling="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
+        <div class="sc-credit"><a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a> &middot; <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a></div>
       </section>
     <section class="ai-chat">
       <h2>🎤 Ask the DJ</h2>

--- a/music.html
+++ b/music.html
@@ -24,7 +24,36 @@
   </header>
   <main class="music-section">
     <h1>Latest Mixes</h1>
-    <p>Check back soon for a curated selection of sets and releases.</p>
+    <div class="music-grid">
+      <div>
+        <iframe
+          width="100%"
+          height="300"
+          scrolling="no"
+          allow="autoplay"
+          src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true">
+        </iframe>
+        <div class="sc-credit">
+          <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+          &middot;
+          <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a>
+        </div>
+      </div>
+      <div>
+        <iframe
+          width="100%"
+          height="166"
+          scrolling="no"
+          allow="autoplay"
+          src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2094603729&color=%23ff5500&auto_play=false&show_user=true">
+        </iframe>
+        <div class="sc-credit">
+          <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+          &middot;
+          <a href="https://soundcloud.com/thebadguyhimself" target="_blank">Track on SoundCloud</a>
+        </div>
+      </div>
+    </div>
   </main>
   <footer>
     <p>&copy; 2025 TheBadGuy / BaddBeats. All rights reserved.</p>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,3 +12,6 @@ routes = [
 [vars]
 # Add your OpenAI API key in the Cloudflare dashboard or via `wrangler secret put`.
 OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+
+[observability.logs]
+enabled = true


### PR DESCRIPTION
## Summary
- clean up SoundCloud embed markup and remove obsolete `frameborder` attributes
- reuse `.sc-credit` styling in `index.html`
- keep music page playlist and track embeds in a grid

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bc5b7b7c832894fcc65780ca4da5