### PR TITLE
Add matching video section

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -38,7 +38,16 @@
 
       <div class="video-embed">
         <h2>Latest Videos</h2>
-        <iframe width="560" height="315" src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself" title="YouTube playlist" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself"
+          title="Latest Videos playlist"
+          loading="lazy"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen>
+        </iframe>
       </div>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -53,8 +53,19 @@
     </section>
 
     <section class="video-section">
-      <h2>🎬 Latest Videos</h2>
-      <iframe width="560" height="315" src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself" title="YouTube playlist" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <div class="video-embed">
+        <h2>Latest Videos</h2>
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself"
+          title="Latest Videos playlist"
+          loading="lazy"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen>
+        </iframe>
+      </div>
     </section>
 
     <section class="ai-chat">


### PR DESCRIPTION
## Summary
- adjust `index.html` to include a `video-embed` block styled like the contact page
- load YouTube playlist lazily on homepage and contact page for better performance

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d1ad8470832895bb92aa4f24e812