### PR TITLE
Remove API key placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,16 @@ baddbeatz/
 ## 🤖 AI Chat Setup
 
 The homepage chat feature sends questions to a Cloudflare Worker endpoint.
-Set your OpenAI API key as a secret so the worker can contact the API:
+Before you deploy the worker, provide your OpenAI API key as a secret so it can
+contact the API:
 
 ```bash
 wrangler secret put OPENAI_API_KEY
 ```
 
-Or configure the variable in the Cloudflare dashboard. The frontend calls
-`/api/ask` which the worker proxies to OpenAI.
+You can also set `OPENAI_API_KEY` in the Cloudflare dashboard. The key is not
+stored in `wrangler.toml` to keep credentials out of version control. The
+frontend calls `/api/ask`, which the worker proxies to OpenAI.
 
 
 ## 🛠 Local Development

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,9 +9,11 @@ routes = [
   { pattern = "www.baddbeatz.nl", custom_domain = true }
 ]
 
+
 [vars]
-# Add your OpenAI API key in the Cloudflare dashboard or via `wrangler secret put`.
-OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+# Provide your OpenAI API key via `wrangler secret put OPENAI_API_KEY`
+# or by setting the variable in the Cloudflare dashboard. The value is
+# intentionally omitted here so it isn't committed to version control.
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary
- remove the OPENAI key placeholder from `wrangler.toml`
- explain how to add the key via `wrangler secret` in the README

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849a697f2008328ba49833169ae4c33