### PR TITLE
Add OG/Twitter meta tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about TheBadGuyHimself's journey and style." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="About | TheBadGuy">
+  <meta property="og:description" content="Learn about TheBadGuyHimself's journey and style.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About | TheBadGuy">
+  <meta name="twitter:description" content="Learn about TheBadGuyHimself's journey and style.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>About | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/bookings.html
+++ b/bookings.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Bookings | TheBadGuy">
+  <meta property="og:description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bookings | TheBadGuy">
+  <meta name="twitter:description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Bookings | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css" />
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Contact | TheBadGuy">
+  <meta property="og:description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Contact | TheBadGuy">
+  <meta name="twitter:description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Contact | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/about.html
+++ b/docs/about.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about TheBadGuyHimself's journey and style." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="About | TheBadGuy">
+  <meta property="og:description" content="Learn about TheBadGuyHimself's journey and style.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About | TheBadGuy">
+  <meta name="twitter:description" content="Learn about TheBadGuyHimself's journey and style.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>About | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/bookings.html
+++ b/docs/bookings.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Bookings | TheBadGuy">
+  <meta property="og:description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bookings | TheBadGuy">
+  <meta name="twitter:description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Bookings | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css" />
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Contact | TheBadGuy">
+  <meta property="og:description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Contact | TheBadGuy">
+  <meta name="twitter:description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Contact | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Gallery | TheBadGuy">
+  <meta property="og:description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Gallery | TheBadGuy">
+  <meta name="twitter:description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Gallery | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Official site of TheBadGuyHimself – underground DJ and producer." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Home | TheBadGuyHimself">
+  <meta property="og:description" content="Official site of TheBadGuyHimself – underground DJ and producer.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Home | TheBadGuyHimself">
+  <meta name="twitter:description" content="Official site of TheBadGuyHimself – underground DJ and producer.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Home | TheBadGuyHimself</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/docs/music.html
+++ b/docs/music.html
@@ -3,6 +3,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Stream TheBadGuyHimself's latest mixes and tracks." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Music | TheBadGuy">
+  <meta property="og:description" content="Stream TheBadGuyHimself's latest mixes and tracks.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Music | TheBadGuy">
+  <meta name="twitter:description" content="Stream TheBadGuyHimself's latest mixes and tracks.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Music | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/gallery.html
+++ b/gallery.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Gallery | TheBadGuy">
+  <meta property="og:description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Gallery | TheBadGuy">
+  <meta name="twitter:description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Gallery | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Official site of TheBadGuyHimself – underground DJ and producer." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Home | TheBadGuyHimself">
+  <meta property="og:description" content="Official site of TheBadGuyHimself – underground DJ and producer.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Home | TheBadGuyHimself">
+  <meta name="twitter:description" content="Official site of TheBadGuyHimself – underground DJ and producer.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Home | TheBadGuyHimself</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">

--- a/music.html
+++ b/music.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Stream TheBadGuyHimself's latest mixes and tracks." />
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Music | TheBadGuy">
+  <meta property="og:description" content="Stream TheBadGuyHimself's latest mixes and tracks.">
+  <meta property="og:image" content="assets/images/placeholder/dj-profile.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Music | TheBadGuy">
+  <meta name="twitter:description" content="Stream TheBadGuyHimself's latest mixes and tracks.">
+  <meta name="twitter:image" content="assets/images/placeholder/dj-profile.jpg">
   <title>Music | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/cyberpunk.css">


### PR DESCRIPTION
## Summary
- embed OG and Twitter cards into HTML templates

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849b546d7e083288be53093879fbb3c