### PR TITLE
Add worker tests and meta tag check

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest
 requests
+requests_mock
+

--- a/tests/socialLinks.test.js
+++ b/tests/socialLinks.test.js
@@ -12,3 +12,9 @@ test('music page embeds the SoundCloud playlist', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'music.html'), 'utf8');
   expect(html).toContain('https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421');
 });
+
+test('index page contains responsive viewport meta tag', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  expect(html).toContain('<meta name="viewport" content="width=device-width, initial-scale=1.0">');
+});
+

--- a/tests/test_worker_logic.py
+++ b/tests/test_worker_logic.py
@@ -1,0 +1,34 @@
+import requests
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import requests_mock
+import pytest
+
+from worker_logic import ask, SYSTEM_PROMPT
+
+
+def test_worker_ask_success():
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={"id": "123", "choices": [{"message": {"content": "hello"}}]},
+            status_code=200,
+        )
+        result = ask("Hello?", "sk-test")
+        assert result["id"] == "123"
+        history = m.request_history[0]
+        assert history.json()["messages"][0]["content"] == SYSTEM_PROMPT
+        assert history.headers["Authorization"] == "Bearer sk-test"
+
+
+def test_worker_ask_error():
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.openai.com/v1/chat/completions",
+            status_code=500,
+            json={"error": "oops"},
+        )
+        with pytest.raises(requests.exceptions.HTTPError):
+            ask("Hi", "sk-test")
+

--- a/worker_logic.py
+++ b/worker_logic.py
@@ -1,0 +1,22 @@
+import requests
+
+SYSTEM_PROMPT = "You are an AI DJ assistant for TheBadGuyHimself."
+
+
+def ask(question: str, api_key: str):
+    url = "https://api.openai.com/v1/chat/completions"
+    payload = {
+        "model": "gpt-3.5-turbo",
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ],
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    response = requests.post(url, json=payload, headers=headers)
+    response.raise_for_status()
+    return response.json()
+


### PR DESCRIPTION
## Summary
- test the Cloudflare worker proxy logic in Python
- check for viewport meta tag in index page

## Testing
- `npm ci`
- `npm test`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849b56f57e48328b59c74948124d64a