### PR TITLE
Add MIT license reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 TheBadGuy / BaddBeatz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -87,4 +87,6 @@ wrangler secret put OPENAI_API_KEY
 Or configure the variable in the Cloudflare dashboard. The frontend calls
 `/api/ask` which the worker proxies to OpenAI.
 
+## License
 
+This project is licensed under the [MIT License](LICENSE).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,11 +6,11 @@ import requests
 
 def test_server_serves_index():
     env = os.environ.copy()
-    env["PORT"] = "8001"
+    env["PORT"] = "8123"
     proc = subprocess.Popen(["python3", "server.py"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
         time.sleep(2)  # give the server time to start
-        response = requests.get("http://localhost:8001/index.html")
+        response = requests.get("http://localhost:8123/index.html")
         assert response.status_code == 200
     finally:
         proc.terminate()


### PR DESCRIPTION
## Summary
- add MIT License text
- reference license in README
- adjust server test port to avoid conflicts

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849582c56fc8328a7167e40c52f465b