### PR TITLE
Add asset import helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ The `docs/` directory used for GitHub Pages is generated from these source files
 
 ---
 
+### Importing Local Assets
+
+If you already have images, CSS, or JavaScript files saved elsewhere (for example on
+Windows at `C:\Users\Behee\OneDrive\Bureaublad\Website bestanden`), you can copy
+them into this project automatically. Run the helper script and provide the path
+to your asset folder:
+
+```bash
+python3 scripts/import_assets.py "C:\Users\Behee\OneDrive\Bureaublad\Website bestanden"
+```
+
+Files matching common image, CSS, and JS extensions will be placed in the
+appropriate subfolders under `assets/`.
+
+---
+
 ## 📦 Dependencies
 ---
 

--- a/scripts/import_assets.py
+++ b/scripts/import_assets.py
@@ -1,0 +1,33 @@
+import argparse
+import shutil
+from pathlib import Path
+
+ASSET_TYPES = {
+    'images': ['*.jpg', '*.jpeg', '*.png', '*.gif', '*.svg', '*.webp'],
+    'css': ['*.css'],
+    'js': ['*.js']
+}
+
+def copy_assets(src_dir, dest_dir):
+    src_path = Path(src_dir)
+    dest_path = Path(dest_dir)
+    if not src_path.exists():
+        raise FileNotFoundError(f"Source directory '{src_dir}' does not exist")
+
+    for category, patterns in ASSET_TYPES.items():
+        target = dest_path / category
+        target.mkdir(parents=True, exist_ok=True)
+        for pattern in patterns:
+            for file in src_path.rglob(pattern):
+                shutil.copy2(file, target / file.name)
+
+def main():
+    parser = argparse.ArgumentParser(description="Copy local assets into the project's assets directory")
+    parser.add_argument('source', help='Path to the folder containing your assets')
+    parser.add_argument('--dest', default='assets', help='Destination assets directory')
+    args = parser.parse_args()
+    copy_assets(args.source, args.dest)
+    print(f"Assets imported from {args.source} to {args.dest}/")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/import_assets.py` script for copying local images, CSS, and JS files
- document how to use the new script in README

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849bf4a9b4c8328a5f7806feb982505