### PR TITLE
Add dotenv example and env-based API key fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=<your-key>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ You can also set `OPENAI_API_KEY` in the Cloudflare dashboard. The key is not
 stored in `wrangler.toml` to keep credentials out of version control. The
 frontend calls `/api/ask`, which the worker proxies to OpenAI.
 
+For local development, copy `.env.example` to `.env` and place your OpenAI key
+inside. `worker_logic.py` and the worker script fall back to the
+`OPENAI_API_KEY` environment variable when not running on Cloudflare.
+
 To protect the API from abuse, create a KV namespace for rate limiting:
 
 ```bash
@@ -124,6 +128,12 @@ Install the project dependencies:
 ```bash
 npm ci
 pip install -r requirements-dev.txt
+```
+
+Create a `.env` file for your API key:
+
+```bash
+cp .env.example .env
 ```
 
 Start the local development server:

--- a/tests/test_worker_logic.py
+++ b/tests/test_worker_logic.py
@@ -32,3 +32,17 @@ def test_worker_ask_error():
         with pytest.raises(requests.exceptions.HTTPError):
             ask("Hi", "sk-test")
 
+
+def test_worker_ask_env_fallback(monkeypatch):
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={"id": "456", "choices": [{"message": {"content": "hi"}}]},
+            status_code=200,
+        )
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        result = ask("Yo")
+        assert result["id"] == "456"
+        history = m.request_history[0]
+        assert history.headers["Authorization"] == "Bearer sk-env"
+

--- a/worker_logic.py
+++ b/worker_logic.py
@@ -1,9 +1,13 @@
+import os
 import requests
 
 SYSTEM_PROMPT = "You are an AI DJ assistant for TheBadGuyHimself."
 
 
-def ask(question: str, api_key: str):
+def ask(question: str, api_key: str | None = None):
+    api_key = api_key or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY is not set")
     url = "https://api.openai.com/v1/chat/completions"
     payload = {
         "model": "gpt-3.5-turbo",

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -31,11 +31,19 @@ export default {
         }
         await env.RATE_LIMIT.put(key, String(count + 1), { expirationTtl: 60 });
 
+        const openaiKey = env.OPENAI_API_KEY || process.env.OPENAI_API_KEY;
+        if (!openaiKey) {
+          return new Response(
+            JSON.stringify({ error: 'Missing OpenAI API key' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+
         const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${env.OPENAI_API_KEY}`
+            'Authorization': `Bearer ${openaiKey}`
           },
           body: JSON.stringify({
             model: 'gpt-3.5-turbo',


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder OPENAI_API_KEY
- document using `.env` for local dev in README
- read `OPENAI_API_KEY` from env in `worker_logic.py`
- fallback to env var in worker script
- test env variable fallback

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849cc8f1b6c8328b293fa20cc691d5b