### PR TITLE
Improve styling and clarify GitHub Pages deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,9 +2,9 @@
 
 This is a static DJ portfolio website built with HTML, CSS, and JavaScript. It features a cyberpunk theme with embedded music players, categorization, tracklists, download options, call to action buttons, and a contact form.
 
-## Deployment on Cloudflare Pages
+## Deployment on GitHub Pages
 
-Follow these steps to deploy the website on Cloudflare Pages:
+Follow these steps to deploy the website on GitHub Pages:
 
 1. **Prepare your project:**
    - Ensure all website files (HTML, CSS, JS, assets) are in the `baddbeatz` directory.
@@ -14,22 +14,19 @@ Follow these steps to deploy the website on Cloudflare Pages:
    - Create a repository on GitHub, GitLab, or Bitbucket.
    - Commit and push the contents of the `baddbeatz` folder to the repository.
 
-3. **Create a Cloudflare Pages project:**
-   - Log in to your Cloudflare dashboard.
-   - Navigate to the Pages section and click "Create a project".
-   - Connect your Git repository to Cloudflare Pages.
+3. **Enable GitHub Pages:**
+   - In your repository, go to **Settings → Pages**.
+   - Choose **GitHub Actions** as the source.
 
-4. **Configure build settings:**
-   - Leave the build command empty (no build step needed).
-   - Set the build output directory to the root folder (`/` or `baddbeatz` depending on your repo structure).
+4. **Deploy:**
+   - Push commits to the `main` branch.
+   - The workflow in `.github/workflows/pages.yml` publishes the `docs/` folder to GitHub Pages.
 
-5. **Deploy:**
-   - Cloudflare Pages will automatically build and deploy your site.
-   - You will receive a live URL to access your DJ portfolio.
+5. **Custom domain:**
+   - After DNS is configured, set `baddbeatz.nl` as your custom domain in the Pages settings.
 
 6. **Update and redeploy:**
-   - Push any future changes to your Git repository.
-   - Cloudflare Pages will automatically redeploy the updated site.
+   - Push any future changes to `main` and the site will redeploy automatically.
 
 ## Local Testing
 
@@ -46,4 +43,4 @@ Then open `http://localhost:8000` in your browser.
 For any questions or support, please contact the developer.
 
 ---
-This document provides all necessary steps to deploy and maintain your DJ portfolio website on Cloudflare Pages.
+This document provides all necessary steps to deploy and maintain your DJ portfolio website on GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BaddBeatz Website - TheBadGuy (TBG)
 
-This is the static portfolio website for **TheBadGuy (TBG)** – a high-energy underground DJ blending house, techno, hardstyle, and uptempo styles. This site is built to be deployed on **Cloudflare Pages**.
+This is the static portfolio website for **TheBadGuy (TBG)** – a high-energy underground DJ blending house, techno, hardstyle, and uptempo styles. This site is built to be deployed on **GitHub Pages**.
 
 ---
 
@@ -25,16 +25,15 @@ baddbeatz/
 
 ---
 
-## 🌐 Deploy to Cloudflare Pages
+## 🌐 Deploy to GitHub Pages
 
-### 1. Login to [Cloudflare Pages](https://pages.cloudflare.com/)
-### 2. Create a new project:
-- Choose **"Direct Upload"**
-- Upload the entire contents of the `baddbeatz/` folder
+The repository contains a GitHub Actions workflow that publishes the contents
+of the `docs/` directory whenever changes are pushed to the `main` branch.
 
-### 3. Set your custom domain:
-- In your Cloudflare dashboard, go to **Pages > Settings > Custom Domains**
-- Add: `baddbeatz.nl`
+1. Commit your updates and push to `main`.
+2. The workflow builds the site and deploys it to GitHub Pages automatically.
+3. In your repository **Settings → Pages**, set the custom domain to
+   `baddbeatz.nl` after pointing your DNS records to GitHub.
 
 ---
 

--- a/about.html
+++ b/about.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Learn about TheBadGuyHimself's journey and style." />
   <title>About | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -22,7 +24,7 @@
       </ul>
     </nav>
   </header>
-  <main class="info-section">
+  <main class="info-section fade-in">
     <h1>About TheBadGuy</h1>
     <p>Underground vibes, high-energy sets, and a passion for pushing boundaries. More details coming soon.</p>
   </main>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -131,3 +131,20 @@ body {
   color: #cccccc;
   text-decoration: none;
 }
+
+/* Responsive video wrapper */
+.video-embed {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-embed iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/bookings.html
+++ b/bookings.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
   <title>Bookings | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="booking-section">
+  <main class="booking-section fade-in">
     <h1>Book TheBadGuy</h1>
     <p>
       Ready to blow up your venue or event? TBG brings relentless energy to clubs, festivals, livestreams and underground raves.

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
   <title>Contact | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="contact-section">
+  <main class="contact-section fade-in">
     <h1>Let’s Talk Beats</h1>
     <p>For bookings, collabs, or just to vibe — hit up TheBadGuy directly:</p>
 

--- a/docs/about.html
+++ b/docs/about.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Learn about TheBadGuyHimself's journey and style." />
   <title>About | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -22,7 +24,7 @@
       </ul>
     </nav>
   </header>
-  <main class="info-section">
+  <main class="info-section fade-in">
     <h1>About TheBadGuy</h1>
     <p>Underground vibes, high-energy sets, and a passion for pushing boundaries. More details coming soon.</p>
   </main>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -131,3 +131,20 @@ body {
   color: #cccccc;
   text-decoration: none;
 }
+
+/* Responsive video wrapper */
+.video-embed {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-embed iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/docs/bookings.html
+++ b/docs/bookings.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Book TheBadGuy (TBG) for your club night, festival, or underground event. Pure energy and powerful sets.">
   <title>Bookings | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="booking-section">
+  <main class="booking-section fade-in">
     <h1>Book TheBadGuy</h1>
     <p>
       Ready to blow up your venue or event? TBG brings relentless energy to clubs, festivals, livestreams and underground raves.

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Contact TheBadGuy (TBG) for bookings, collaborations or general inquiries.">
   <title>Contact | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="contact-section">
+  <main class="contact-section fade-in">
     <h1>Let’s Talk Beats</h1>
     <p>For bookings, collabs, or just to vibe — hit up TheBadGuy directly:</p>
 

--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
   <title>Gallery | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="gallery-section">
+  <main class="gallery-section fade-in">
     <h1>Visuals & Vibes</h1>
     <p>Step inside the chaos. A glimpse of TBG's world: live sets, behind-the-scenes, and raw underground moments.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Official site of TheBadGuyHimself – underground DJ and producer." />
   <title>Home | TheBadGuyHimself</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
   <script defer src="assets/js/main.js"></script>
 </head>
@@ -30,28 +32,29 @@
       <h1>BADDBEATS by THEBADGUYHIMSELF</h1>
       <p class="tagline">High-energy underground techno and hardstyle</p>
       <div class="cta-buttons">
-        <a href="music.html" class="btn">🎧 Listen to Mixes</a>
-        <a href="gallery.html" class="btn">📸 View Gallery</a>
-        <a href="bookings.html" class="btn">📩 Book Now</a>
+        <a href="music.html" class="btn-secondary">🎧 Listen to Mixes</a>
+        <a href="gallery.html" class="btn-secondary">📸 View Gallery</a>
+        <a href="bookings.html" class="btn-primary">📩 Book Now</a>
       </div>
     </div>
   </section>
 
   <main>
-    <section class="intro">
+    <section class="intro fade-in">
       <h2>Who is TheBadGuyHimself?</h2>
       <p>With over 4 years of electrifying dancefloors, he blends explosive techno, rawstyle bangers, and seamless transitions to keep crowds locked in the groove.</p>
     </section>
 
-    <section class="featured-mix">
+    <section class="featured-mix fade-in">
       <h2>🔥 Featured Mix</h2>
       <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-      <div style="font-size: 10px; color: #cccccc; line-break: anywhere; word-break: normal; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif; font-weight: 100;">
-        <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank" style="color: #cccccc; text-decoration: none;">TBGxTheBadGuy</a> ·
-        <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank" style="color: #cccccc; text-decoration: none;">House mixes 2025</a>
+      <div class="sc-credit">
+        <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+        &middot;
+        <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a>
       </div>
     </section>
-    <section class="video-section">
+    <section class="video-section fade-in">
       <div class="video-embed">
         <h2>Latest Videos</h2>
         <iframe
@@ -67,7 +70,7 @@
       </div>
     </section>
       
-    <section class="ai-chat">
+   <section class="ai-chat fade-in">
       <h2>🎤 Ask the DJ</h2>
       <p>Curious about TheBadGuyHimself's setup, vibe, or availability? Ask below!</p>
       <textarea id="userInput" placeholder="Type your question..."></textarea>

--- a/docs/music.html
+++ b/docs/music.html
@@ -5,6 +5,8 @@
   <meta name="description" content="Stream TheBadGuyHimself's latest mixes and tracks." />
   <title>Music | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -21,7 +23,7 @@
       </ul>
     </nav>
   </header>
-  <main class="music-section">
+  <main class="music-section fade-in">
     <h1>Latest Mixes</h1>
     <div class="music-grid">
       <div>

--- a/gallery.html
+++ b/gallery.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Gallery of TheBadGuy's performances, behind-the-scenes moments, and event visuals.">
   <title>Gallery | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -23,7 +25,7 @@
     </nav>
   </header>
 
-  <main class="gallery-section">
+  <main class="gallery-section fade-in">
     <h1>Visuals & Vibes</h1>
     <p>Step inside the chaos. A glimpse of TBG's world: live sets, behind-the-scenes, and raw underground moments.</p>
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Official site of TheBadGuyHimself – underground DJ and producer." />
   <title>Home | TheBadGuyHimself</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
   <script defer src="assets/js/main.js"></script>
 </head>
@@ -30,34 +32,35 @@
       <h1>BADDBEATS by THEBADGUYHIMSELF</h1>
       <p class="tagline">High-energy underground techno and hardstyle</p>
       <div class="cta-buttons">
-        <a href="music.html" class="btn">🎧 Listen to Mixes</a>
-        <a href="gallery.html" class="btn">📸 View Gallery</a>
-        <a href="bookings.html" class="btn">📩 Book Now</a>
+        <a href="music.html" class="btn-secondary">🎧 Listen to Mixes</a>
+        <a href="gallery.html" class="btn-secondary">📸 View Gallery</a>
+        <a href="bookings.html" class="btn-primary">📩 Book Now</a>
       </div>
     </div>
   </section>
 
   <main>
-    <section class="intro">
+    <section class="intro fade-in">
       <h2>Who is TheBadGuyHimself?</h2>
       <p>With over 4 years of electrifying dancefloors, he blends explosive techno, rawstyle bangers, and seamless transitions to keep crowds locked in the groove.</p>
     </section>
 
-    <section class="featured-mix">
+    <section class="featured-mix fade-in">
       <h2>🔥 Featured Mix</h2>
       <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/2019398421&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
-      <div style="font-size: 10px; color: #cccccc; line-break: anywhere; word-break: normal; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif; font-weight: 100;">
-        <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank" style="color: #cccccc; text-decoration: none;">TBGxTheBadGuy</a> ·
-        <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank" style="color: #cccccc; text-decoration: none;">House mixes 2025</a>
+      <div class="sc-credit">
+        <a href="https://soundcloud.com/thebadguyhimself" title="TBGxTheBadGuy" target="_blank">TBGxTheBadGuy</a>
+        &middot;
+        <a href="https://soundcloud.com/thebadguyhimself/sets/house-mixes-2025" title="House mixes 2025" target="_blank">House mixes 2025</a>
       </div>
     </section>
-    <section class="video-section">
+    <section class="video-section fade-in">
       <div class="video-embed">
         <h2>Latest Videos</h2>
         <iframe width="560" height="315" src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself" title="YouTube playlist" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </section>
-   <section class="ai-chat">
+   <section class="ai-chat fade-in">
 
       <h2>🎤 Ask the DJ</h2>
       <p>Curious about TheBadGuyHimself's setup, vibe, or availability? Ask below!</p>

--- a/music.html
+++ b/music.html
@@ -6,6 +6,8 @@
   <meta name="description" content="Stream TheBadGuyHimself's latest mixes and tracks." />
   <title>Music | TheBadGuy</title>
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -22,7 +24,7 @@
       </ul>
     </nav>
   </header>
-  <main class="music-section">
+  <main class="music-section fade-in">
     <h1>Latest Mixes</h1>
     <div class="music-grid">
       <div>


### PR DESCRIPTION
## Summary
- document GitHub Pages deployment in README and DEPLOYMENT guide
- add cyberpunk and responsive styles to all HTML pages
- use existing btn-primary/btn-secondary classes on hero buttons
- apply fade-in animation and responsive video wrapper
- simplify SoundCloud credit markup

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68495d4a5eb883289fb22c9ea887d769