### PR TITLE
Add 404 page and worker support

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found | BaddBeatz</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/enhanced-cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <div class="nav__brand">BaddBeatz</div>
+      <button class="nav__toggle" aria-label="Toggle navigation">
+        <span class="nav__toggle-line"></span>
+        <span class="nav__toggle-line"></span>
+        <span class="nav__toggle-line"></span>
+      </button>
+      <ul class="nav__links">
+        <li><a class="nav__link" href="index.html">Home</a></li>
+        <li><a class="nav__link" href="about.html">About</a></li>
+        <li><a class="nav__link" href="music.html">Music</a></li>
+        <li><a class="nav__link" href="gallery.html">Gallery</a></li>
+        <li><a class="nav__link" href="bookings.html">Bookings</a></li>
+        <li><a class="nav__link" href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="info-section fade-in">
+    <h1>404 - Page Not Found</h1>
+    <p>The page you're looking for doesn't exist.</p>
+    <a href="index.html" class="btn-primary">Return Home</a>
+  </main>
+  <footer>
+    <p>&copy; 2025 TheBadGuy / BaddBeatz. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found | BaddBeatz</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/enhanced-cyberpunk.css">
+  <link rel="stylesheet" href="assets/css/responsive.css">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <nav class="nav">
+      <div class="nav__brand">BaddBeatz</div>
+      <button class="nav__toggle" aria-label="Toggle navigation">
+        <span class="nav__toggle-line"></span>
+        <span class="nav__toggle-line"></span>
+        <span class="nav__toggle-line"></span>
+      </button>
+      <ul class="nav__links">
+        <li><a class="nav__link" href="index.html">Home</a></li>
+        <li><a class="nav__link" href="about.html">About</a></li>
+        <li><a class="nav__link" href="music.html">Music</a></li>
+        <li><a class="nav__link" href="gallery.html">Gallery</a></li>
+        <li><a class="nav__link" href="bookings.html">Bookings</a></li>
+        <li><a class="nav__link" href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="info-section fade-in">
+    <h1>404 - Page Not Found</h1>
+    <p>The page you're looking for doesn't exist.</p>
+    <a href="index.html" class="btn-primary">Return Home</a>
+  </main>
+  <footer>
+    <p>&copy; 2025 TheBadGuy / BaddBeatz. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -21,7 +21,8 @@ async function main() {
     'music.html',
     'gallery.html',
     'bookings.html',
-    'contact.html'
+    'contact.html',
+    '404.html'
   ];
   const otherFiles = ['robots.txt', 'sitemap.xml', 'CNAME'];
 

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -70,8 +70,14 @@ export default {
     try {
       return await getAssetFromKV({ request, waitUntil: ctx.waitUntil.bind(ctx) });
     } catch (e) {
-      const pathname = url.pathname;
-      return new Response(`"${pathname}" not found`, { status: 404, statusText: 'not found' });
+      try {
+        const notFoundRequest = new Request(url.origin + '/404.html', request);
+        const res = await getAssetFromKV({ request: notFoundRequest, waitUntil: ctx.waitUntil.bind(ctx) });
+        return new Response(res.body, { ...res, status: 404 });
+      } catch (err) {
+        const pathname = url.pathname;
+        return new Response(`"${pathname}" not found`, { status: 404, statusText: 'not found' });
+      }
     }
   }
 };


### PR DESCRIPTION
## Summary
- add new `404.html` page with same layout as other pages
- update docs build script to copy the new page
- modify Cloudflare worker to serve `404.html` for missing assets

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b0938355483288bda08b1f4603ab9