### PR TITLE
Add timeout handling for OpenAI requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ For local development, copy `.env.example` to `.env` and place your OpenAI key
 inside. `worker_logic.py` and the worker script fall back to the
 `OPENAI_API_KEY` environment variable when not running on Cloudflare.
 
+Requests to the OpenAI API use a 10-second timeout. If the API does not respond
+within this window, `worker_logic.ask` will raise a
+`requests.exceptions.Timeout` error.
+
 To protect the API from abuse, create a KV namespace for rate limiting:
 
 ```bash

--- a/tests/test_worker_logic.py
+++ b/tests/test_worker_logic.py
@@ -46,3 +46,13 @@ def test_worker_ask_env_fallback(monkeypatch):
         history = m.request_history[0]
         assert history.headers["Authorization"] == "Bearer sk-env"
 
+
+def test_worker_ask_timeout():
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://api.openai.com/v1/chat/completions",
+            exc=requests.exceptions.Timeout,
+        )
+        with pytest.raises(requests.exceptions.Timeout):
+            ask("Hi", "sk-test")
+

--- a/worker_logic.py
+++ b/worker_logic.py
@@ -20,7 +20,7 @@ def ask(question: str, api_key: str | None = None):
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
-    response = requests.post(url, json=payload, headers=headers)
+    response = requests.post(url, json=payload, headers=headers, timeout=10)
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
## Summary
- add 10s timeout when calling OpenAI API in `worker_logic.ask`
- test timeout path in `test_worker_logic.py`
- document request timeout behavior in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0937b5348328a06d2bc1cc4966ea