### PR TITLE
Add Flask API with authentication

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,15 +1,27 @@
+function authHeaders() {
+  const token = localStorage.getItem('authToken');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function loadPlaylist() {
-  const res = await fetch('/api/tracks');
+  const res = await fetch('/api/tracks', { headers: authHeaders() });
+  if (!res.ok) {
+    console.error('Failed to load tracks', await res.text());
+    return [];
+  }
   const data = await res.json();
   return data.tracks || [];
 }
 
 async function addTrack(title, url) {
-  await fetch('/api/tracks', {
+  const res = await fetch('/api/tracks', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ title, url })
   });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
 }
 
 function createPlayer(tracks) {

--- a/docs/assets/js/player.js
+++ b/docs/assets/js/player.js
@@ -1,15 +1,27 @@
+function authHeaders() {
+  const token = localStorage.getItem('authToken');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function loadPlaylist() {
-  const res = await fetch('/api/tracks');
+  const res = await fetch('/api/tracks', { headers: authHeaders() });
+  if (!res.ok) {
+    console.error('Failed to load tracks', await res.text());
+    return [];
+  }
   const data = await res.json();
   return data.tracks || [];
 }
 
 async function addTrack(title, url) {
-  await fetch('/api/tracks', {
+  const res = await fetch('/api/tracks', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ title, url })
   });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
 }
 
 function createPlayer(tracks) {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 pytest
 requests
 requests_mock
+Flask
+Werkzeug
 

--- a/server.py
+++ b/server.py
@@ -1,57 +1,111 @@
-import http.server
-import socketserver
 import os
-import json
+import sqlite3
+import secrets
+from flask import Flask, request, jsonify, send_from_directory
+from werkzeug.security import generate_password_hash, check_password_hash
 
-# Allow overriding the port via the PORT environment variable
-PORT = int(os.getenv("PORT", "8000"))
-DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "tracks.json")
+app = Flask(__name__, static_folder='.', static_url_path='')
 
+DB_PATH = os.path.join(os.path.dirname(__file__), 'data', 'app.db')
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 
-class Handler(http.server.SimpleHTTPRequestHandler):
-    def do_GET(self):
-        if self.path == "/api/tracks":
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            try:
-                with open(DATA_FILE) as f:
-                    data = json.load(f)
-            except FileNotFoundError:
-                data = {"tracks": []}
-            self.wfile.write(json.dumps(data).encode())
-        else:
-            super().do_GET()
+tokens: dict[str, int] = {}
 
-    def do_POST(self):
-        if self.path == "/api/tracks":
-            length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(length)
-            try:
-                track = json.loads(body)
-            except json.JSONDecodeError:
-                self.send_response(400)
-                self.end_headers()
-                return
-            os.makedirs(os.path.dirname(DATA_FILE), exist_ok=True)
-            try:
-                with open(DATA_FILE) as f:
-                    data = json.load(f)
-            except FileNotFoundError:
-                data = {"tracks": []}
-            data["tracks"].append(track)
-            with open(DATA_FILE, "w") as f:
-                json.dump(data, f)
-            self.send_response(201)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(track).encode())
-        else:
-            self.send_response(404)
-            self.end_headers()
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    with get_db() as conn:
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS tracks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, url TEXT)'
+        )
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT)'
+        )
+
+init_db()
 
 
-with socketserver.TCPServer(("", PORT), Handler) as httpd:
-    print(f"Serving at port {PORT}")
-    print(f"Open http://localhost:{PORT} in your browser")
-    httpd.serve_forever()
+def get_user_id_from_token() -> int | None:
+    auth = request.headers.get('Authorization', '')
+    if auth.startswith('Bearer '):
+        token = auth.split(' ', 1)[1]
+        return tokens.get(token)
+    return None
+
+
+@app.route('/api/tracks', methods=['GET'])
+def get_tracks():
+    with get_db() as conn:
+        rows = conn.execute('SELECT id, title, url FROM tracks').fetchall()
+    return jsonify({'tracks': [dict(row) for row in rows]})
+
+
+@app.route('/api/tracks', methods=['POST'])
+def add_track():
+    if not get_user_id_from_token():
+        return jsonify({'error': 'Unauthorized'}), 401
+    data = request.get_json(silent=True) or {}
+    title = data.get('title')
+    url = data.get('url')
+    if not title or not url:
+        return jsonify({'error': 'Missing fields'}), 400
+    with get_db() as conn:
+        cur = conn.execute('INSERT INTO tracks (title, url) VALUES (?, ?)', (title, url))
+        conn.commit()
+        track = {'id': cur.lastrowid, 'title': title, 'url': url}
+    return jsonify(track), 201
+
+
+@app.route('/api/register', methods=['POST'])
+def register():
+    data = request.get_json(silent=True) or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Missing fields'}), 400
+    pw_hash = generate_password_hash(password)
+    try:
+        with get_db() as conn:
+            cur = conn.execute(
+                'INSERT INTO users (username, password_hash) VALUES (?, ?)',
+                (username, pw_hash),
+            )
+            conn.commit()
+            user_id = cur.lastrowid
+    except sqlite3.IntegrityError:
+        return jsonify({'error': 'User exists'}), 400
+    token = secrets.token_hex(16)
+    tokens[token] = user_id
+    return jsonify({'token': token})
+
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    data = request.get_json(silent=True) or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Missing fields'}), 400
+    with get_db() as conn:
+        row = conn.execute(
+            'SELECT id, password_hash FROM users WHERE username=?', (username,)
+        ).fetchone()
+    if not row or not check_password_hash(row['password_hash'], password):
+        return jsonify({'error': 'Invalid credentials'}), 401
+    token = secrets.token_hex(16)
+    tokens[token] = row['id']
+    return jsonify({'token': token})
+
+
+@app.route('/', defaults={'path': 'index.html'})
+@app.route('/<path:path>')
+def static_files(path: str):
+    return send_from_directory('.', path)
+
+
+if __name__ == '__main__':
+    port = int(os.getenv('PORT', '8000'))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- replace SimpleHTTPServer with Flask
- store tracks and users in SQLite
- add login/register endpoints and token auth
- handle auth errors in `player.js`
- update docs and test requirements

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e80c9007483288b1aad8599e1c0cd