### PR TITLE
Integrate Gemini CLI support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=<your-key>
+GEMINI_API_KEY=<your-gemini-key>

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ For local development, copy `.env.example` to `.env` and place your OpenAI key
 inside. `worker_logic.py` and the worker script fall back to the
 `OPENAI_API_KEY` environment variable when not running on Cloudflare.
 
+If you'd like to experiment with Google's Gemini models locally, install
+`gemini-cli` and set `GEMINI_API_KEY` in your `.env` file. The helper script
+`gemini_logic.py` shows how to call the API using Python.
+
 Requests to the OpenAI API use a 10-second timeout. If the API does not respond
 within this window, `worker_logic.ask` will raise a
 `requests.exceptions.Timeout` error.
@@ -131,6 +135,7 @@ Before deploying, replace the placeholder `id` and `preview_id` values in
 ### Environment Variables
 
 - `OPENAI_API_KEY` – required by the Cloudflare Worker and `worker_logic.py`.
+- `GEMINI_API_KEY` – optional key for using `gemini_logic.py`.
 - `PORT` – optional port for the Flask app (defaults to `8000`).
 - `DB_PATH` – optional path to the SQLite database file used by the Flask app.
 

--- a/gemini_logic.py
+++ b/gemini_logic.py
@@ -1,0 +1,32 @@
+import os
+import requests
+
+SYSTEM_PROMPT = "You are an AI DJ assistant for TheBadGuyHimself."
+
+
+def ask(question: str, api_key: str | None = None):
+    """Query the Gemini API and return the response JSON."""
+    api_key = api_key or os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is not set")
+
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-pro:generateContent"
+    )
+    params = {"key": api_key}
+    payload = {
+        "contents": [
+            {"role": "user", "parts": [{"text": f"{SYSTEM_PROMPT}\n{question}"}]}
+        ]
+    }
+    response = requests.post(url, params=params, json=payload, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    text = (
+        data.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
+    return {"text": text}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ Flask
 Werkzeug
 
 Flask
+google-generativeai

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+google-generativeai

--- a/tests/test_gemini_logic.py
+++ b/tests/test_gemini_logic.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import requests_mock
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from gemini_logic import ask, SYSTEM_PROMPT
+
+
+def test_gemini_ask_success():
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+            json={"candidates": [{"content": {"parts": [{"text": "hi"}]}}]},
+            status_code=200,
+        )
+        result = ask("Hello?", "sk-test")
+        assert result["text"] == "hi"
+        history = m.request_history[0]
+        assert "sk-test" in history.url
+
+
+def test_gemini_ask_env_fallback(monkeypatch):
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+            json={"candidates": [{"content": {"parts": [{"text": "hello"}]}}]},
+            status_code=200,
+        )
+        monkeypatch.setenv("GEMINI_API_KEY", "env-test")
+        result = ask("Yo")
+        assert result["text"] == "hello"
+        history = m.request_history[0]
+        assert "env-test" in history.url
+
+
+def test_gemini_ask_error():
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+            status_code=500,
+            json={"error": "oops"},
+        )
+        with pytest.raises(Exception):
+            ask("Hi", "sk-test")


### PR DESCRIPTION
## Summary
- add `gemini_logic.py` helper for Gemini API
- document Gemini setup in README and `.env.example`
- include `google-generativeai` in requirements
- add unit tests for the new Gemini logic

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686067d3091c8328929a72d75fcbc8fb