### PR TITLE
Add Hugging Face support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 OPENAI_API_KEY=<your-key>
 GEMINI_API_KEY=<your-gemini-key>
+HF_MODEL=sshleifer/tiny-gpt2

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ If you'd like to experiment with Google's Gemini models locally, install
 `gemini-cli` and set `GEMINI_API_KEY` in your `.env` file. The helper script
 `gemini_logic.py` shows how to call the API using Python.
 
+For open source models, install the `transformers` package and set `HF_MODEL`
+to your preferred model name (defaults to `sshleifer/tiny-gpt2`). The helper
+module `huggingface_logic.py` demonstrates using a Hugging Face pipeline.
+
 Requests to the OpenAI API use a 10-second timeout. If the API does not respond
 within this window, `worker_logic.ask` will raise a
 `requests.exceptions.Timeout` error.
@@ -136,6 +140,7 @@ Before deploying, replace the placeholder `id` and `preview_id` values in
 
 - `OPENAI_API_KEY` – required by the Cloudflare Worker and `worker_logic.py`.
 - `GEMINI_API_KEY` – optional key for using `gemini_logic.py`.
+- `HF_MODEL` – optional Hugging Face model name for `huggingface_logic.py`.
 - `PORT` – optional port for the Flask app (defaults to `8000`).
 - `DB_PATH` – optional path to the SQLite database file used by the Flask app.
 

--- a/huggingface_logic.py
+++ b/huggingface_logic.py
@@ -1,0 +1,26 @@
+import os
+from transformers import pipeline
+
+# Default small model to load if none provided
+DEFAULT_MODEL = "sshleifer/tiny-gpt2"
+
+_pipeline = None
+_model_name = None
+
+
+def _get_pipeline(model_name: str):
+    """Load and cache the transformers pipeline for text generation."""
+    global _pipeline, _model_name
+    if _pipeline is None or model_name != _model_name:
+        _pipeline = pipeline("text-generation", model=model_name)
+        _model_name = model_name
+    return _pipeline
+
+
+def ask(question: str, model_name: str | None = None):
+    """Generate a response using a Hugging Face model."""
+    model_name = model_name or os.getenv("HF_MODEL", DEFAULT_MODEL)
+    nlp = _get_pipeline(model_name)
+    outputs = nlp(question, max_new_tokens=20)
+    text = outputs[0].get("generated_text", "")
+    return {"text": text}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ Werkzeug
 
 Flask
 google-generativeai
+transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 google-generativeai
+transformers

--- a/tests/test_huggingface_logic.py
+++ b/tests/test_huggingface_logic.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import huggingface_logic
+
+
+def test_hf_ask_success(monkeypatch):
+    calls = {}
+    
+    def fake_pipeline(task, model=None):
+        calls['task'] = task
+        calls['model'] = model
+        def run(prompt, max_new_tokens=20):
+            calls['prompt'] = prompt
+            calls['max_new_tokens'] = max_new_tokens
+            return [{"generated_text": "hi"}]
+        return run
+    monkeypatch.setattr(huggingface_logic, 'pipeline', fake_pipeline)
+    result = huggingface_logic.ask("Hello?", "test-model")
+    assert result["text"] == "hi"
+    assert calls['task'] == 'text-generation'
+    assert calls['model'] == 'test-model'
+
+
+def test_hf_ask_env_fallback(monkeypatch):
+    def fake_pipeline(task, model=None):
+        def run(prompt, max_new_tokens=20):
+            return [{"generated_text": "hello"}]
+        return run
+    monkeypatch.setattr(huggingface_logic, 'pipeline', fake_pipeline)
+    monkeypatch.setenv("HF_MODEL", "env-model")
+    result = huggingface_logic.ask("Yo")
+    assert result["text"] == "hello"
+
+
+def test_hf_ask_error(monkeypatch):
+    def fake_pipeline(task, model=None):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(huggingface_logic, 'pipeline', fake_pipeline)
+    with pytest.raises(RuntimeError):
+        huggingface_logic.ask("Hi", "bad-model")


### PR DESCRIPTION
## Summary
- add `huggingface_logic.py` using `transformers` pipeline
- include `transformers` in requirements files
- document Hugging Face usage and environment variable
- add HF_MODEL to `.env.example`
- test the new helper

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ddafef448328a011219315c5f94f