### PR TITLE
Integrate Gemini CLI support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=<your-key>
+GEMINI_API_KEY=<your-gemini-key>

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ For local development, copy `.env.example` to `.env` and place your OpenAI key
 inside. `worker_logic.py` and the worker script fall back to the
 `OPENAI_API_KEY` environment variable when not running on Cloudflare.
 
+If you'd like to experiment with Google's Gemini models locally, install
+`gemini-cli` and set `GEMINI_API_KEY` in your `.env` file. The helper script
+`gemini_logic.py` demonstrates using the official `google-generativeai`
+package to send a prompt to Gemini.
+
 Requests to the OpenAI API use a 10-second timeout. If the API does not respond
 within this window, `worker_logic.ask` will raise a
 `requests.exceptions.Timeout` error.
@@ -131,6 +136,7 @@ Before deploying, replace the placeholder `id` and `preview_id` values in
 ### Environment Variables
 
 - `OPENAI_API_KEY` – required by the Cloudflare Worker and `worker_logic.py`.
+- `GEMINI_API_KEY` – optional key for using `gemini_logic.py`.
 - `PORT` – optional port for the Flask app (defaults to `8000`).
 - `DB_PATH` – optional path to the SQLite database file used by the Flask app.
 

--- a/gemini_logic.py
+++ b/gemini_logic.py
@@ -1,0 +1,16 @@
+import os
+import google.generativeai as genai
+
+SYSTEM_PROMPT = "You are an AI DJ assistant for TheBadGuyHimself."
+
+
+def ask(question: str, api_key: str | None = None):
+    """Query the Gemini API and return the response JSON."""
+    api_key = api_key or os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is not set")
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel("gemini-pro", system_instruction=SYSTEM_PROMPT)
+    result = model.generate_content(question)
+    return {"text": result.text}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ Flask
 Werkzeug
 
 Flask
+google-generativeai

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+google-generativeai

--- a/tests/test_gemini_logic.py
+++ b/tests/test_gemini_logic.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from gemini_logic import ask, SYSTEM_PROMPT
+
+
+def test_gemini_ask_success():
+    with patch("gemini_logic.genai") as mock_genai:
+        model = mock_genai.GenerativeModel.return_value
+        model.generate_content.return_value = MagicMock(text="hi")
+
+        result = ask("Hello?", "sk-test")
+
+        mock_genai.configure.assert_called_with(api_key="sk-test")
+        mock_genai.GenerativeModel.assert_called_with(
+            "gemini-pro", system_instruction=SYSTEM_PROMPT
+        )
+        model.generate_content.assert_called_with("Hello?")
+        assert result["text"] == "hi"
+
+
+def test_gemini_ask_env_fallback(monkeypatch):
+    with patch("gemini_logic.genai") as mock_genai:
+        model = mock_genai.GenerativeModel.return_value
+        model.generate_content.return_value = MagicMock(text="hello")
+        monkeypatch.setenv("GEMINI_API_KEY", "env-test")
+
+        result = ask("Yo")
+
+        mock_genai.configure.assert_called_with(api_key="env-test")
+        assert result["text"] == "hello"
+
+
+def test_gemini_ask_error():
+    with patch("gemini_logic.genai") as mock_genai:
+        model = mock_genai.GenerativeModel.return_value
+        model.generate_content.side_effect = RuntimeError("oops")
+
+        with pytest.raises(RuntimeError):
+            ask("Hi", "sk-test")


### PR DESCRIPTION
## Summary
- add `gemini_logic.py` helper for Gemini API
- document Gemini setup in README and `.env.example`
- include `google-generativeai` in requirements
- add unit tests for the new Gemini logic
- refactor Gemini helper to use the official SDK

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686067d3091c8328929a72d75fcbc8fb