### PR TITLE
Persist auth tokens in SQLite

### DIFF
--- a/tests/test_server_tokens.py
+++ b/tests/test_server_tokens.py
@@ -1,0 +1,60 @@
+import os
+import socket
+import subprocess
+import time
+import requests
+
+
+def get_free_port():
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def start_server(port, db_path):
+    env = os.environ.copy()
+    env["PORT"] = str(port)
+    env["DB_PATH"] = db_path
+    return subprocess.Popen(["python3", "server.py"], env=env,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_token_persists_across_restarts(tmp_path):
+    port = get_free_port()
+    db_file = str(tmp_path / "test.db")
+    proc = start_server(port, db_file)
+    try:
+        time.sleep(2)
+        res = requests.post(f"http://localhost:{port}/api/register",
+                            json={"username": "u", "password": "p"})
+        assert res.status_code == 200
+        token = res.json()["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        r1 = requests.post(
+            f"http://localhost:{port}/api/tracks",
+            json={"title": "t1", "url": "http://e.com/1"},
+            headers=headers,
+        )
+        assert r1.status_code == 201
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    proc2 = start_server(port, db_file)
+    try:
+        time.sleep(2)
+        r2 = requests.post(
+            f"http://localhost:{port}/api/tracks",
+            json={"title": "t2", "url": "http://e.com/2"},
+            headers=headers,
+        )
+        assert r2.status_code == 201
+        list_res = requests.get(f"http://localhost:{port}/api/tracks")
+        assert list_res.status_code == 200
+        tracks = list_res.json()["tracks"]
+        assert len(tracks) == 2
+    finally:
+        proc2.terminate()
+        proc2.wait(timeout=5)


### PR DESCRIPTION
## Summary
- persist auth tokens in SQLite on register/login
- reload tokens from database when server starts
- enable `DB_PATH` env var in `server.py`
- add tests ensuring token persistence after restart

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68653f9a7be08328b200d8706dcd2454