### PR TITLE
Fix repeated DB init

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,6 @@ def init_db():
 
 @app.route('/api/tracks', methods=['GET', 'POST'])
 def tracks():
-    init_db()
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     if request.method == 'POST':

--- a/server.py
+++ b/server.py
@@ -25,7 +25,6 @@ def init_db():
             'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT)'
         )
 
-init_db()
 
 
 def get_user_id_from_token() -> int | None:
@@ -107,5 +106,6 @@ def static_files(path: str):
 
 
 if __name__ == '__main__':
+    init_db()
     port = int(os.getenv('PORT', '8000'))
     app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- remove redundant init_db call inside the `/api/tracks` route
- call init_db during startup in server.py

## Testing
- `npm ci`
- `npm test`
- `pip install -r requirements-dev.txt`
- `pip install Flask`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68653f9856e08328b13fc0c0fb00c6cc