### PR TITLE
Add YouTube API endpoint and front-end loader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 OPENAI_API_KEY=<your-key>
 GEMINI_API_KEY=<your-gemini-key>
+# API key for YouTube Data API
+YOUTUBE_API_KEY=<your-key>
 # See https://github.com/codex/remove-codex-comments-and-urls
 # For gemini-cli setup instructions, see the documentation:
 # https://example.com/gemini-cli

--- a/assets/js/youtube.js
+++ b/assets/js/youtube.js
@@ -1,0 +1,22 @@
+async function loadYoutubeVideos() {
+  const list = document.getElementById('youtubeVideos');
+  if (!list) return;
+  try {
+    const channelId = list.dataset.channelId || 'UC_x5XG1OV2P6uZZ5FSM9Ttw';
+    const res = await fetch(`/api/youtube?channel_id=${encodeURIComponent(channelId)}`);
+    const data = await res.json();
+    list.innerHTML = '';
+    (data.videos || []).forEach(v => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = `https://www.youtube.com/watch?v=${v.id}`;
+      a.textContent = v.title;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  } catch (err) {
+    list.textContent = 'Failed to load videos.';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadYoutubeVideos);

--- a/huggingface_logic.py
+++ b/huggingface_logic.py
@@ -1,5 +1,9 @@
 import os
-from transformers import pipeline
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency may be missing
+    def pipeline(*_args, **_kwargs):
+        raise ImportError("transformers is not installed")
 
 # Default small model to load if none provided
 DEFAULT_MODEL = "sshleifer/tiny-gpt2"

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="assets/css/responsive.css">
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter&display=swap" rel="stylesheet">
   <script defer src="assets/js/main.js"></script>
+  <script defer src="assets/js/youtube.js"></script>
 </head>
 <body>
   <header>
@@ -73,6 +74,7 @@
       <div class="video-embed">
         <h2>Latest Videos</h2>
         <iframe width="560" height="315" src="https://www.youtube.com/embed?listType=user_uploads&amp;list=TheBadGuyHimself" title="YouTube playlist" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <ul id="youtubeVideos" data-channel-id="UC_x5XG1OV2P6uZZ5FSM9Ttw"></ul>
       </div>
     </section>
    <section class="ai-chat fade-in">

--- a/tests/test_youtube_endpoint.py
+++ b/tests/test_youtube_endpoint.py
@@ -1,0 +1,20 @@
+import os
+import requests_mock
+
+
+def test_youtube_endpoint(tmp_path):
+    db_file = str(tmp_path / "test.db")
+    os.environ["DB_PATH"] = db_file
+    os.environ["YOUTUBE_API_KEY"] = "test-key"
+    import server
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://www.googleapis.com/youtube/v3/search",
+            json={"items": [{"id": {"videoId": "abc"}, "snippet": {"title": "Test"}}]},
+            status_code=200,
+        )
+        client = server.app.test_client()
+        res = client.get("/api/youtube?channel_id=cid")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["videos"][0]["id"] == "abc"

--- a/youtube_logic.py
+++ b/youtube_logic.py
@@ -1,0 +1,29 @@
+import os
+import requests
+
+def get_latest_videos(channel_id: str, api_key: str | None = None, max_results: int = 5):
+    """Return a list of the latest videos from a YouTube channel."""
+    api_key = api_key or os.getenv("YOUTUBE_API_KEY")
+    if not api_key:
+        raise ValueError("YOUTUBE_API_KEY is not set")
+    url = "https://www.googleapis.com/youtube/v3/search"
+    params = {
+        "key": api_key,
+        "channelId": channel_id,
+        "part": "snippet",
+        "order": "date",
+        "type": "video",
+        "maxResults": max_results,
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    videos = [
+        {
+            "id": item.get("id", {}).get("videoId"),
+            "title": item.get("snippet", {}).get("title"),
+        }
+        for item in items
+        if "videoId" in item.get("id", {})
+    ]
+    return {"videos": videos}


### PR DESCRIPTION
## Summary
- integrate YouTube Data API helper
- expose `/api/youtube` route for recent videos
- load latest videos in the homepage
- allow missing transformers in `huggingface_logic`
- document `YOUTUBE_API_KEY` in example env
- test YouTube endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865476db8f083288b2cdf5c3543f3cc