### PR TITLE
Ensure dotenv variables load automatically

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@ import os
 import sqlite3
 from flask import Flask, request, jsonify, send_from_directory
 from youtube_logic import get_latest_videos
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Serve files from `docs` if present; otherwise serve from repo root
 static_dir = 'docs' if os.path.isdir(os.path.join(os.path.dirname(__file__), 'docs')) else ''

--- a/server.py
+++ b/server.py
@@ -4,6 +4,9 @@ import secrets
 from flask import Flask, request, jsonify, send_from_directory
 from youtube_logic import get_latest_videos
 from werkzeug.security import generate_password_hash, check_password_hash
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Serve files from the `docs` directory if it exists, else from the repo root
 static_dir = 'docs' if os.path.isdir(os.path.join(os.path.dirname(__file__), 'docs')) else ''


### PR DESCRIPTION
## Summary
- read `.env` via `python-dotenv` in `app.py`
- read `.env` via `python-dotenv` in `server.py`

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865a3acc88c83289af8dc6acdd68872