### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/6](https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/6)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow primarily performs read operations (e.g., checking out code, setting up environments, installing dependencies), the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimum access required to complete its tasks.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
