### PR TITLE
Potential fix for code scanning alert no. 3: Binding a socket to all network interfaces

### DIFF
--- a/tests/test_server_tokens.py
+++ b/tests/test_server_tokens.py
@@ -7,7 +7,7 @@ import requests
 
 def get_free_port():
     sock = socket.socket()
-    sock.bind(("", 0))
+    sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
     sock.close()
     return port


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/3](https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/3)

To fix the issue, the socket should be bound to a specific interface instead of all interfaces. For testing purposes, the loopback interface (`127.0.0.1`) can be used, as it restricts connections to the local machine. This ensures that the socket is not exposed to external networks while maintaining the functionality of the `get_free_port()` function.

The changes will be made in the `get_free_port()` function in the file `tests/test_server_tokens.py`. Specifically, the `sock.bind(("", 0))` line will be updated to bind the socket to the loopback interface (`127.0.0.1`) instead of all interfaces.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
