### PR TITLE
[dj-portfolio] Build docs automatically on npm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ baddbeatz/
     ├── images/
 ```
 
-The `docs/` directory used for GitHub Pages is generated automatically with `npm run build-docs` and should not be committed.
+The `docs/` directory used for GitHub Pages is generated automatically with `npm run build-docs` and should not be committed. Running `npm test` will build this folder automatically if it's missing.
 
 ---
 
@@ -191,7 +191,7 @@ other libraries needed for the test suite.
 
 - JavaScript tests:
 
-Run `npm ci` before executing `npm test`:
+Run `npm ci` before executing `npm test`. The test command automatically generates the `docs/` folder if it's not present:
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "deploy": "wrangler deploy",
+    "pretest": "node scripts/ensure-docs.js",
     "test": "jest",
     "build-docs": "node scripts/build-docs.js"
   },

--- a/scripts/ensure-docs.js
+++ b/scripts/ensure-docs.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const docsPath = path.join(__dirname, '..', 'docs');
+if (!fs.existsSync(docsPath)) {
+  console.log('docs/ folder missing, generating with "npm run build-docs"...');
+  execSync('npm run build-docs', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- generate docs automatically if missing before running tests
- document automatic docs build in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d765e7d883288c6cc7e33b1708fc