### PR TITLE
[baddbeatz] fix(ci): correct workflow indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,12 @@ jobs:
         id: requirements-dev
         run: echo "exists=$(if [ -f requirements-dev.txt ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
         working-directory: ${{ github.workspace }}
-
       - uses: actions/setup-python@v4
         if: steps.requirements-dev.outputs.exists == 'true'
         with:
           python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: requirements-dev.txt
-
       - run: pip install -r requirements-dev.txt
         if: steps.requirements-dev.outputs.exists == 'true'
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- fix indentation for Python-related steps in CI workflow

## Testing
- `pnpm test` *(fails: ReferenceError: require is not defined)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_686db756d6848328b79482cb0ddff1cd