### PR TITLE
fix: pin charset-normalizer to 3.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==23.2.0
 blinker==1.8.2
 cachetools==5.3.3
 certifi==2024.8.30
-charset-normalizer==3.4.3
+charset-normalizer==3.4.2
 click==8.2.1
 colorama==0.4.7
 flask==3.0.3


### PR DESCRIPTION
## Summary
- pin charset-normalizer dependency to 3.4.2 to avoid yanked 3.4.3 release

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for colorama==0.4.7)*
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/baddbeatz/docs/contact.html')*
- `flake8 .` *(fails: tests/test_security_fixed.py:193:1: W293 blank line contains whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_68902d53b9088328be50f2a6897fe923