### PR TITLE
fix: constrain click dependency

### DIFF
--- a/DEPENDABOT_COMPREHENSIVE_TESTING_REPORT.md
+++ b/DEPENDABOT_COMPREHENSIVE_TESTING_REPORT.md
@@ -35,7 +35,7 @@
 **Critical Conflicts Found**:
 1. `pydantic 2.11.7` requires `pydantic-core==2.33.2` but has `2.37.2`
 2. `flask-limiter 3.12` requires `rich<14>=12` but has `14.1.0`
-3. `gtts 2.5.4` requires `click<8.2>=7.1` but has `8.2.1`
+3. `gtts 2.5.4` requires `click<8.2>=7.1` and now uses `8.1.8`
 4. `google-auth 2.40.3` requires `cachetools<6.0>=2.0.0` but has `6.1.0`
 5. `safety 3.6.0` requires `pydantic<2.10.0>=2.6.0` but has `2.11.7`
 6. Multiple version conflicts with `psutil`, `filelock`, and other packages
@@ -86,7 +86,7 @@
 |-------|----------------|------------------|---------|----------|
 | pydantic-core | 2.37.2 | 2.33.2 | High | 🔴 Critical |
 | rich | 14.1.0 | <14>=12 | Medium | 🟡 High |
-| click | 8.2.1 | <8.2>=7.1 | Medium | 🟡 High |
+| click | 8.1.8 | <8.2>=7.1 | None | ✅ Resolved |
 | cachetools | 6.1.0 | <6.0>=2.0.0 | Medium | 🟡 High |
 | pydantic | 2.11.7 | <2.10.0>=2.6.0 | High | 🔴 Critical |
 

--- a/DEPENDABOT_SECURITY_ALERTS_REMEDIATION_PLAN.md
+++ b/DEPENDABOT_SECURITY_ALERTS_REMEDIATION_PLAN.md
@@ -23,7 +23,7 @@ From the `DEPENDENCY_SECURITY_REVIEW.md`, I identified:
 - **Issues Found**:
   1. `pydantic-core` version mismatch (required: 2.33.2, installed: 2.23.4)
   2. `rich` version conflict (required: <14>=12, installed: 14.1.0)
-  3. `click` version conflict (required: <8.2>=7.1, installed: 8.2.1)
+  3. `click` version requirement (required: <8.2>=7.1, installed: 8.1.8)
   4. `cachetools` version conflict (required: <6.0>=2.0.0, installed: 6.1.0)
   5. `pydantic` conflicts (required: <2.10.0>=2.6.0, installed: 2.11.7)
 

--- a/DEPENDENCY_SECURITY_REVIEW.md
+++ b/DEPENDENCY_SECURITY_REVIEW.md
@@ -47,9 +47,9 @@ Conducted comprehensive dependency security review across all project components
    - flask-limiter requires: `rich<14>=12`
    - Installed: `rich 14.1.0`
 
-3. **click version conflict**:
+3. **click version requirement (resolved)**:
    - gtts requires: `click<8.2>=7.1`
-   - Installed: `click 8.2.1`
+   - Installed: `click 8.1.8`
 
 4. **cachetools version conflict**:
    - google-auth requires: `cachetools<6.0>=2.0.0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ blinker==1.8.2
 cachetools==5.3.3
 certifi==2024.8.30
 charset-normalizer==3.4.2
-click==8.2.1
+click>=7.1,<8.2
 colorama==0.4.6
 flask==3.0.3
 flask-sqlalchemy==3.1.1


### PR DESCRIPTION
## Summary
- constrain click dependency to <8.2 to satisfy gTTS
- refresh security documentation to reference click 8.1.8

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm test` *(fails: Missing script "build-docs")*
- `flake8 .` *(errors: W293, E302, E501...)*
- `pytest` *(errors during collection)*
- `html5validator --root . --match "*.html" --ignore-re "Attribute.*not allowed"` *(HTML validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890447aaff083288037a203a9cca2bb