### PR TITLE
Remove deprecated X-XSS-Protection header

### DIFF
--- a/CRITICAL_SECURITY_FIXES_SUMMARY.md
+++ b/CRITICAL_SECURITY_FIXES_SUMMARY.md
@@ -41,9 +41,9 @@
   - Content-Security-Policy with strict rules
   - X-Frame-Options: DENY (clickjacking protection)
   - X-Content-Type-Options: nosniff
-  - X-XSS-Protection: 1; mode=block
   - Strict-Transport-Security (HSTS)
   - Referrer-Policy: strict-origin-when-cross-origin
+  - Removed deprecated X-XSS-Protection header in favor of CSP
 
 ## 🛡️ **Security Improvements Implemented**
 

--- a/SECURITY_AUDIT_AND_FIXES.md
+++ b/SECURITY_AUDIT_AND_FIXES.md
@@ -71,9 +71,9 @@ Created `csp-config.js` with recommended CSP headers:
 Via `workers-site/security-headers.js`:
 - X-Frame-Options: DENY
 - X-Content-Type-Options: nosniff
-- X-XSS-Protection: 1; mode=block
 - Strict-Transport-Security (HSTS)
 - Referrer-Policy: strict-origin-when-cross-origin
+- Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none'
 
 ## 🚨 Critical Security Issues to Address
 

--- a/server.py
+++ b/server.py
@@ -10,8 +10,12 @@ class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         # Add security headers for local testing
         self.send_header('X-Content-Type-Options', 'nosniff')
         self.send_header('X-Frame-Options', 'DENY')
-        self.send_header('X-XSS-Protection', '1; mode=block')
         self.send_header('Referrer-Policy', 'strict-origin-when-cross-origin')
+        # Modern browsers ignore X-XSS-Protection; use CSP instead
+        self.send_header(
+            'Content-Security-Policy',
+            "default-src 'self'; script-src 'self'; object-src 'none'"
+        )
         super().end_headers()
 
     def do_GET(self):
@@ -26,7 +30,7 @@ with socketserver.TCPServer(("", PORT), MyHTTPRequestHandler) as httpd:
     print(f"Server running at http://localhost:{PORT}/")
     print(f"Directory: {os.getcwd()}")
     print("\nSecurity features enabled:")
-    print("- XSS Protection headers")
+    print("- Content Security Policy active")
     print("- Frame options set to DENY")
     print("- Content type sniffing disabled")
     print("\nPress Ctrl+C to stop the server")


### PR DESCRIPTION
## Summary
- drop deprecated X-XSS-Protection header from local server
- serve a simple CSP header instead
- document security header update in audit reports

## Testing
- `pnpm turbo run test --filter baddbeatz` *(fails: Command "turbo" not found)*
- `pnpm lint --filter baddbeatz` *(fails: Invalid option '--ignore-missing')*
- `pnpm test`
- `python server.py & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6890447ddf188328bb5ae3ba631b7383