### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update-dependencies:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/25](https://github.com/CrzyHAX91/baddbeatz/security/code-scanning/25)

To fix the problem, add an explicit `permissions` block to the workflow. The best approach is to set the minimal permissions required at the job level (or at the workflow level if all jobs need the same permissions). In this workflow, only the step that creates a pull request needs write access to `contents` and `pull-requests`; the rest of the steps only need read access. The simplest and most secure fix is to add a `permissions` block to the `update-dependencies` job, specifying `contents: write` and `pull-requests: write`. This should be added just above `runs-on: ubuntu-latest` (line 10).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
