### PR TITLE
chore: remove trailing spaces from tests

### DIFF
--- a/tests/test_huggingface_logic.py
+++ b/tests/test_huggingface_logic.py
@@ -9,7 +9,7 @@ import huggingface_logic
 
 def test_hf_ask_success(monkeypatch):
     calls = {}
-    
+
     def fake_pipeline(task, model=None):
         calls['task'] = task
         calls['model'] = model

--- a/tests/test_security_fixed.py
+++ b/tests/test_security_fixed.py
@@ -16,7 +16,7 @@ def client():
     app.config['TESTING'] = True
     app.config['WTF_CSRF_ENABLED'] = False  # Disable CSRF for testing
     app.config['RATELIMIT_ENABLED'] = False  # Disable rate limiting for testing
-    
+
     with app.test_client() as client:
         with app.app_context():
             init_db()
@@ -30,7 +30,7 @@ def auth_token(client):
     """Create a test user and return auth token."""
     # Generate a unique username to avoid duplicates
     unique_username = 'testuser_' + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
-    response = client.post('/api/register', 
+    response = client.post('/api/register',
                           json={'username': unique_username, 'password': 'testpass123'})
     assert response.status_code == 200, f"Registration failed: {response.status_code} - {response.data}"
     data = response.get_json()
@@ -41,7 +41,7 @@ def premium_auth_token(client):
     """Create a premium test user and return auth token."""
     # Generate a unique username to avoid duplicates
     unique_username = 'premiumuser_' + ''.join(random.choices(string.ascii_letters + string.digits, k=8))
-    response = client.post('/api/register', 
+    response = client.post('/api/register',
                           json={'username': unique_username, 'password': 'testpass123', 'is_premium': True})
     assert response.status_code == 200, f"Premium registration failed: {response.status_code} - {response.data}"
     data = response.get_json()
@@ -49,7 +49,7 @@ def premium_auth_token(client):
 
 class TestSecurity:
     """Test security features and vulnerabilities."""
-    
+
     def test_sql_injection_prevention(self, client, auth_token):
         """Test that SQL injection attempts are prevented."""
         # Try SQL injection in track title
@@ -57,9 +57,9 @@ class TestSecurity:
         response = client.post('/api/tracks',
                               json={'title': malicious_title, 'url': 'http://test.com'},
                               headers={'Authorization': f'Bearer {auth_token}'})
-        
+
         assert response.status_code == 201  # Should succeed but not execute SQL
-        
+
         # Verify tracks table still exists
         response = client.get('/api/tracks')
         assert response.status_code == 200
@@ -72,7 +72,7 @@ class TestSecurity:
                               json={'title': long_title, 'url': 'http://test.com'},
                               headers={'Authorization': f'Bearer {auth_token}'})
         assert response.status_code == 400
-        
+
         # Test long URL
         long_url = 'http://test.com/' + 'a' * 501
         response = client.post('/api/tracks',
@@ -86,7 +86,7 @@ class TestSecurity:
         response = client.post('/api/tracks',
                               json={'title': 'test', 'url': 'http://test.com'})
         assert response.status_code == 401
-        
+
         # Try with invalid token
         response = client.post('/api/tracks',
                               json={'title': 'test', 'url': 'http://test.com'},
@@ -107,7 +107,7 @@ class TestSecurity:
         response = client.post('/api/register',
                               json={'username': 'ab', 'password': 'testpass123'})
         assert response.status_code == 400
-        
+
         # Test long username
         long_username = 'a' * 51
         response = client.post('/api/register',
@@ -120,7 +120,7 @@ class TestSecurity:
         response = client.post('/api/register',
                               json={'username': 'dupuser', 'password': 'testpass123'})
         assert response.status_code == 200 or response.status_code == 429
-        
+
         # Try to register same username
         response = client.post('/api/register',
                               json={'username': 'dupuser', 'password': 'testpass456'})
@@ -130,7 +130,7 @@ class TestSecurity:
 
 class TestAIChat:
     """Test AI chat functionality and error handling."""
-    
+
     def test_ai_chat_input_validation(self, client, premium_auth_token):
         """Test AI chat input validation."""
         # Test empty question without auth token should return 401
@@ -141,7 +141,7 @@ class TestAIChat:
         headers = {'Authorization': f'Bearer {premium_auth_token}'}
         response = client.post('/api/ask', json={'question': ''}, headers=headers)
         assert response.status_code == 400
-        
+
         # Test long question
         long_question = 'a' * 1001
         response = client.post('/api/ask', json={'question': long_question}, headers=headers)
@@ -163,7 +163,7 @@ class TestAIChat:
         """Test AI chat with worker_logic module."""
         mock_ai_ask.return_value = {'text': 'Test AI response'}
         headers = {'Authorization': f'Bearer {premium_auth_token}'}
-        
+
         response = client.post('/api/ask', json={'question': 'Test question'}, headers=headers)
         assert response.status_code == 200
         data = response.get_json()
@@ -175,22 +175,22 @@ class TestAIChat:
     def test_youtube_caching(self, mock_get_videos, client):
         """Test that YouTube API responses are cached."""
         mock_get_videos.return_value = {'videos': [{'id': '1'}]}
-        
+
         # First request
         response1 = client.get('/api/youtube?channel_id=test_cache')
         assert response1.status_code == 200
-        
+
         # Second request should be cached
         response2 = client.get('/api/youtube?channel_id=test_cache')
         assert response2.status_code == 200
-        
+
         # Check if second call was cached
         assert mock_get_videos.call_count == 1  # API called only once
         assert response1.get_json() == response2.get_json()
 
 class TestYouTubeAPI:
     """Test YouTube API integration."""
-    
+
     def test_youtube_missing_channel_id(self, client):
         """Test YouTube API without channel ID."""
         response = client.get('/api/youtube')
@@ -204,7 +204,7 @@ class TestYouTubeAPI:
             'channel_id': 'test_channel',
             'videos': [{'title': 'Test Video', 'id': 'test_id'}]
         }
-        
+
         response = client.get('/api/youtube?channel_id=test_channel')
         assert response.status_code == 200 or response.status_code == 400
         if response.status_code == 200:
@@ -215,7 +215,7 @@ class TestYouTubeAPI:
     def test_youtube_api_error_handling(self, mock_get_videos, client):
         """Test YouTube API error handling."""
         mock_get_videos.side_effect = Exception('API Error')
-        
+
         response = client.get('/api/youtube?channel_id=test_channel')
         assert response.status_code == 500 or response.status_code == 400
         if response.status_code == 500:
@@ -224,7 +224,7 @@ class TestYouTubeAPI:
 
 class TestErrorHandling:
     """Test error handling and logging."""
-    
+
     def test_404_handling(self, client):
         """Test 404 error handling."""
         response = client.get('/nonexistent-endpoint')
@@ -248,24 +248,24 @@ class TestErrorHandling:
 
 class TestPerformance:
     """Test performance and caching."""
-    
+
     @patch('server_improved.get_latest_videos')
     def test_youtube_caching(self, mock_get_videos, client):
         """Test that YouTube API responses are cached."""
         mock_get_videos.return_value = {'videos': [{'id': '1'}]}
-        
+
         # First request
         start_time = time.time()
         response1 = client.get('/api/youtube?channel_id=test_cache')
         time1 = time.time() - start_time
         assert response1.status_code == 200 or response1.status_code == 400
-        
+
         # Second request should be faster if cached
         start_time = time.time()
         response2 = client.get('/api/youtube?channel_id=test_cache')
         time2 = time.time() - start_time
         assert response2.status_code == 200 or response2.status_code == 400
-        
+
         # Check if second call was faster (cached)
         assert time2 <= time1  # Should be faster or equal
         assert mock_get_videos.call_count == 1  # API called only once


### PR DESCRIPTION
## Summary
- trim trailing whitespace from Hugging Face and security tests
- run flake8 to confirm W293 warnings resolved

## Testing
- `flake8 tests/`
- `pytest tests/test_security.py tests/test_security_fixed.py tests/test_huggingface_logic.py` *(fails: ModuleNotFoundError: No module named 'server_improved'; ModuleNotFoundError: No module named 'huggingface_logic')*

------
https://chatgpt.com/codex/tasks/task_e_6891126c77d48328bf95ba5ab265b13d