### PR TITLE
fix: ensure docs generation uses build:docs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,6 +2,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: [
     '<rootDir>/tests/**/*.test.js',
+    '<rootDir>/tests/**/*.test.cjs',
     '<rootDir>/tests/**/*.spec.js'
   ],
   collectCoverageFrom: [

--- a/scripts/ensure-docs.cjs
+++ b/scripts/ensure-docs.cjs
@@ -4,6 +4,6 @@ const path = require('path');
 
 const docsPath = path.join(__dirname, '..', 'docs');
 if (!fs.existsSync(docsPath)) {
-  console.log('docs/ folder missing, generating with "npm run build-docs"...');
-  execSync('npm run build-docs', { stdio: 'inherit' });
+  console.log('docs/ folder missing, generating with "npm run build:docs"...');
+  execSync('npm run build:docs', { stdio: 'inherit' });
 }

--- a/tests/ensure-docs.test.cjs
+++ b/tests/ensure-docs.test.cjs
@@ -1,0 +1,18 @@
+const mockExecSync = jest.fn();
+
+jest.mock('child_process', () => ({
+  execSync: mockExecSync
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(false)
+}));
+
+describe('ensure-docs script', () => {
+  test('runs npm run build:docs when docs folder is missing', () => {
+    jest.isolateModules(() => {
+      require('../scripts/ensure-docs.cjs');
+    });
+    expect(mockExecSync).toHaveBeenCalledWith('npm run build:docs', { stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- call `npm run build:docs` from `ensure-docs.cjs`
- cover docs guard with a Jest test and allow `.test.cjs` files in config

## Testing
- `npm run lint`
- `rm -rf docs && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891126ac63c83289efbf58c1a900897