### PR TITLE
chore: bump aiohttp and deps for py312

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.0
-aiohttp==3.10.11
+aiohttp==3.12.15
 aiosignal==1.4.0
 annotated-types==0.7.0
 async-timeout==4.0.3
@@ -20,7 +20,7 @@ google-auth==2.28.2
 google-auth-httplib2==0.2.0
 google-generativeai==0.8.5
 googleapis-common-protos==1.63.2
-greenlet==3.1.1
+greenlet==3.2.3
 grpcio==1.71.2
 grpcio-status==1.71.2
 gunicorn==23.0.0
@@ -50,7 +50,7 @@ typing-inspection==0.4.1
 uritemplate==4.2.0
 urllib3==2.5.0
 werkzeug==3.1.3
-yarl==1.17.2
+yarl==1.20.1
 authlib==1.3.1
 requests-oauthlib==1.3.1
 


### PR DESCRIPTION
## Summary
- update aiohttp to 3.12.x series
- align greenlet and yarl with compatible modern releases

## Testing
- `pip install -r requirements.txt`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891126aa8808328b0b4db9b2981f5ae